### PR TITLE
Add blockchain memory scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,20 @@ If Echofoam holds up to scrutiny, it may offer a new pathway to understanding co
 1. Install requirements  
 ```bash  
 pip install numpy matplotlib  
+```
 
+
+2. Run the simulation or use the blockchain memory module as needed.
+
+## Blockchain Memory Scaffold
+
+The file `blockchain_memory.py` implements a minimal compressed memory chain where each entry references the previous block via its hash. The chain is saved to disk for persistence.
+
+### Example
+```python
+from blockchain_memory import BlockchainMemory
+
+mem = BlockchainMemory("demo_chain.json")
+block = mem.add_memory("an important observation")
+print(block.hash)
+```

--- a/blockchain_memory.py
+++ b/blockchain_memory.py
@@ -1,0 +1,73 @@
+import hashlib
+import json
+import zlib
+from dataclasses import dataclass
+from typing import List, Optional
+
+@dataclass
+class Block:
+    index: int
+    data: bytes
+    prev_hash: str
+    hash: str
+
+class BlockchainMemory:
+    """Simple compressed memory chain with hashed references."""
+
+    def __init__(self, path: str = "memory_chain.json"):
+        self.path = path
+        self.chain: List[Block] = []
+        self.load()
+
+    def _hash_block(self, index: int, data: bytes, prev_hash: str) -> str:
+        h = hashlib.sha256()
+        h.update(str(index).encode())
+        h.update(prev_hash.encode())
+        h.update(data)
+        return h.hexdigest()
+
+    def add_memory(self, text: str) -> Block:
+        """Compress and store text as a new block."""
+        compressed = zlib.compress(text.encode())
+        prev_hash = self.chain[-1].hash if self.chain else "0" * 64
+        index = len(self.chain)
+        block_hash = self._hash_block(index, compressed, prev_hash)
+        block = Block(index, compressed, prev_hash, block_hash)
+        self.chain.append(block)
+        self.persist()
+        return block
+
+    def get_block(self, block_hash: str) -> Optional[Block]:
+        for block in self.chain:
+            if block.hash == block_hash:
+                return block
+        return None
+
+    def persist(self) -> None:
+        serial = [
+            {
+                "index": b.index,
+                "data": b.data.hex(),
+                "prev_hash": b.prev_hash,
+                "hash": b.hash,
+            }
+            for b in self.chain
+        ]
+        with open(self.path, "w") as f:
+            json.dump(serial, f, indent=2)
+
+    def load(self) -> None:
+        try:
+            with open(self.path) as f:
+                serial = json.load(f)
+            self.chain = [
+                Block(
+                    index=entry["index"],
+                    data=bytes.fromhex(entry["data"]),
+                    prev_hash=entry["prev_hash"],
+                    hash=entry["hash"],
+                )
+                for entry in serial
+            ]
+        except FileNotFoundError:
+            self.chain = []

--- a/tests/test_blockchain_memory.py
+++ b/tests/test_blockchain_memory.py
@@ -1,0 +1,33 @@
+import os
+import unittest
+from blockchain_memory import BlockchainMemory
+
+class BlockchainMemoryTest(unittest.TestCase):
+    def setUp(self):
+        self.path = "test_chain.json"
+        if os.path.exists(self.path):
+            os.remove(self.path)
+        self.mem = BlockchainMemory(self.path)
+
+    def tearDown(self):
+        if os.path.exists(self.path):
+            os.remove(self.path)
+
+    def test_add_and_get_block(self):
+        block = self.mem.add_memory("hello world")
+        self.assertEqual(block.index, 0)
+        self.assertTrue(block.hash)
+        retrieved = self.mem.get_block(block.hash)
+        self.assertIsNotNone(retrieved)
+        self.assertEqual(retrieved.hash, block.hash)
+
+    def test_persistence(self):
+        self.mem.add_memory("foo")
+        self.mem.add_memory("bar")
+        hashes_before = [b.hash for b in self.mem.chain]
+        mem2 = BlockchainMemory(self.path)
+        hashes_after = [b.hash for b in mem2.chain]
+        self.assertEqual(hashes_before, hashes_after)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- close README code block and document blockchain memory usage
- implement `blockchain_memory.py` for compressed hash-linked blocks
- add tests covering block creation and persistence

## Testing
- `python -m unittest discover -s tests -v`
