### PR TITLE
Add FFMpegWriter usage to simulations

### DIFF
--- a/laser_filamentation.py
+++ b/laser_filamentation.py
@@ -1,5 +1,6 @@
 import numpy as np
 import matplotlib.pyplot as plt
+from matplotlib.animation import FuncAnimation, FFMpegWriter
 import os
 
 
@@ -18,7 +19,22 @@ def run_simulation(grid_size=128, timesteps=400, save_interval=50,
 
     os.makedirs("frames", exist_ok=True)
 
-    for t in range(timesteps):
+    fig, axes = plt.subplots(1, 3, figsize=(12, 4))
+    im0 = axes[0].imshow(np.abs(psi), origin="lower", cmap="viridis", vmin=0, vmax=1)
+    axes[0].set_title(r"$|\psi|$")
+    fig.colorbar(im0, ax=axes[0])
+
+    im1 = axes[1].imshow(tau, origin="lower", cmap="plasma", vmin=1, vmax=collapse_threshold)
+    axes[1].set_title(r"$\tau$")
+    fig.colorbar(im1, ax=axes[1])
+
+    line, = axes[2].plot([], [])
+    axes[2].set_xlim(0, timesteps)
+    axes[2].set_ylim(0, 1)
+    axes[2].set_title(r"$\chi$")
+
+    def update(t):
+        nonlocal psi, tau
         # Propagate beam by shifting right
         psi = np.roll(psi, 1, axis=1)
 
@@ -28,7 +44,9 @@ def run_simulation(grid_size=128, timesteps=400, save_interval=50,
 
         # Collapse if refractive index becomes too high
         if np.any(tau > collapse_threshold):
-            psi = (np.random.rand(grid_size, grid_size) + 1j * np.random.rand(grid_size, grid_size)) * 0.1
+            psi = (
+                np.random.rand(grid_size, grid_size) + 1j * np.random.rand(grid_size, grid_size)
+            ) * 0.1
             tau[:] = 1.0
             chi = 0.0
         else:
@@ -37,24 +55,16 @@ def run_simulation(grid_size=128, timesteps=400, save_interval=50,
 
         psi *= 0.999  # gradual decoherence
 
-        if t % save_interval == 0:
-            fig, axes = plt.subplots(1, 3, figsize=(12, 4))
-            im0 = axes[0].imshow(np.abs(psi), origin="lower", cmap="viridis", vmin=0, vmax=1)
-            axes[0].set_title(r"$|\psi|$")
-            fig.colorbar(im0, ax=axes[0])
+        im0.set_data(np.abs(psi))
+        im1.set_data(tau)
+        line.set_data(range(len(chi_history)), chi_history)
+        return im0, im1, line
 
-            im1 = axes[1].imshow(tau, origin="lower", cmap="plasma", vmin=1, vmax=collapse_threshold)
-            axes[1].set_title(r"$\tau$")
-            fig.colorbar(im1, ax=axes[1])
-
-            axes[2].plot(chi_history)
-            axes[2].set_xlim(0, timesteps)
-            axes[2].set_ylim(0, 1)
-            axes[2].set_title(r"$\chi$")
-
-            fig.tight_layout()
-            fig.savefig(f"frames/frame_{t:04d}.png")
-            plt.close(fig)
+    ani = FuncAnimation(fig, update, frames=timesteps, interval=50, blit=False, repeat=False)
+    plt.tight_layout()
+    writer = FFMpegWriter(fps=20)
+    ani.save("filamentation.mp4", writer=writer)
+    plt.close(fig)
 
 
 if __name__ == "__main__":

--- a/teleportation.py
+++ b/teleportation.py
@@ -1,6 +1,6 @@
 import numpy as np
 import matplotlib.pyplot as plt
-from matplotlib.animation import FuncAnimation
+from matplotlib.animation import FuncAnimation, FFMpegWriter
 
 # Grid size and simulation steps
 size = 100
@@ -94,5 +94,6 @@ def update(frame):
 
 ani = FuncAnimation(fig, update, frames=steps, interval=50, blit=True, repeat=False)
 plt.tight_layout()
-ani.save("teleport.mp4", writer="ffmpeg")
+writer = FFMpegWriter(fps=20)
+ani.save("teleport.mp4", writer=writer)
 plt.close(fig)


### PR DESCRIPTION
## Summary
- add `FFMpegWriter` imports
- use `FFMpegWriter` when saving animations in the simulation scripts

## Testing
- `pytest -q` *(fails: command not found)*