### PR TITLE
Update import path for BlockchainMemory tests

### DIFF
--- a/tests/test_blockchain_memory.py
+++ b/tests/test_blockchain_memory.py
@@ -1,6 +1,7 @@
 import os
 import unittest
-from blockchain_memory import BlockchainMemory
+# Updated import reflecting package restructuring
+from echofoam_falsifiability_suite.blockchain_memory import BlockchainMemory
 
 class BlockchainMemoryTest(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## Summary
- update test_blockchain_memory import to reflect package name change

## Testing
- `pytest -q` *(fails: ModuleNotFoundError - echofoam_falsifiability_suite)*