### PR TITLE
Encapsulate animations and make modules import-safe

### DIFF
--- a/echofoam_falsifiability/__init__.py
+++ b/echofoam_falsifiability/__init__.py
@@ -1,0 +1,10 @@
+import sys
+from pathlib import Path
+
+_src_pkg = Path(__file__).resolve().parent.parent / 'src' / 'echofoam_falsifiability'
+if _src_pkg.exists():
+    __path__ = [str(_src_pkg)]
+    if str(_src_pkg) not in sys.path:
+        sys.path.insert(0, str(_src_pkg))
+else:
+    __path__ = []

--- a/laser_filamentation.py
+++ b/laser_filamentation.py
@@ -1,0 +1,11 @@
+from echofoam_falsifiability.laser_filamentation import create_animation as _create_animation
+
+
+def create_animation():
+    return _create_animation()
+
+
+if __name__ == "__main__":
+    import matplotlib.pyplot as plt
+    fig, anim = create_animation()
+    plt.show()

--- a/simulation.py
+++ b/simulation.py
@@ -3,7 +3,7 @@ import matplotlib.pyplot as plt
 from matplotlib.animation import FuncAnimation
 
 
-def main():
+def create_animation():
     size = 50
     tau = np.zeros((size, size))
     tau[size // 2, size // 2] = 1.0
@@ -44,6 +44,11 @@ def main():
 
     ani = FuncAnimation(fig, step, frames=500, interval=50, blit=False)
     plt.tight_layout()
+    return fig, ani
+
+
+def main():
+    fig, _ = create_animation()
     plt.show()
 
 if __name__ == '__main__':

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -1,0 +1,8 @@
+import sys
+from pathlib import Path
+root = Path(__file__).resolve().parent
+src_pkg = root / 'src' / 'echofoam_falsifiability'
+if str(root) not in sys.path:
+    sys.path.insert(0, str(root))
+if src_pkg.exists() and str(src_pkg) not in sys.path:
+    sys.path.insert(0, str(src_pkg))

--- a/src/echofoam_falsifiability/laser_filamentation.py
+++ b/src/echofoam_falsifiability/laser_filamentation.py
@@ -1,61 +1,62 @@
 import numpy as np
 import matplotlib.pyplot as plt
-import os
+from matplotlib.animation import FuncAnimation
 
 
-def run_simulation(grid_size=128, timesteps=400, save_interval=50,
-                   alpha=0.01, beta=0.05, collapse_threshold=2.0,
-                   intensity_threshold=0.1):
-    """Run a simple 2D laser filamentation simulation."""
+def create_animation(grid_size=128, timesteps=400, alpha=0.01, beta=0.05,
+                      collapse_threshold=2.0, intensity_threshold=0.1):
     x = np.linspace(-1, 1, grid_size)
     y = np.linspace(-1, 1, grid_size)
     X, Y = np.meshgrid(x, y)
 
-    # Initial coherent Gaussian beam
     psi = np.exp(-(X**2 + Y**2) * 20).astype(np.complex128)
     tau = np.ones((grid_size, grid_size))
     chi_history = []
 
-    os.makedirs("frames", exist_ok=True)
+    fig, axes = plt.subplots(1, 3, figsize=(12, 4))
+    im0 = axes[0].imshow(np.abs(psi), origin="lower", cmap="viridis",
+                         vmin=0, vmax=1, animated=True)
+    axes[0].set_title(r"$|\psi|")
+    fig.colorbar(im0, ax=axes[0])
 
-    for t in range(timesteps):
-        # Propagate beam by shifting right
+    im1 = axes[1].imshow(tau, origin="lower", cmap="plasma",
+                         vmin=1, vmax=collapse_threshold, animated=True)
+    axes[1].set_title(r"$\tau$")
+    fig.colorbar(im1, ax=axes[1])
+
+    line, = axes[2].plot([], [], animated=True)
+    axes[2].set_xlim(0, timesteps)
+    axes[2].set_ylim(0, 1)
+    axes[2].set_title(r"$\chi$")
+
+    def update(t):
+        nonlocal psi, tau
         psi = np.roll(psi, 1, axis=1)
-
         intensity = np.abs(psi) ** 2
         tau += alpha * intensity
         tau += beta * (intensity > intensity_threshold) * intensity**2
 
-        # Collapse if refractive index becomes too high
         if np.any(tau > collapse_threshold):
-            psi = (np.random.rand(grid_size, grid_size) + 1j * np.random.rand(grid_size, grid_size)) * 0.1
+            psi = (np.random.rand(grid_size, grid_size) +
+                   1j * np.random.rand(grid_size, grid_size)) * 0.1
             tau[:] = 1.0
             chi = 0.0
         else:
             chi = np.abs(np.mean(psi)) / (np.mean(np.abs(psi)) + 1e-8)
         chi_history.append(chi)
 
-        psi *= 0.999  # gradual decoherence
+        psi *= 0.999
 
-        if t % save_interval == 0:
-            fig, axes = plt.subplots(1, 3, figsize=(12, 4))
-            im0 = axes[0].imshow(np.abs(psi), origin="lower", cmap="viridis", vmin=0, vmax=1)
-            axes[0].set_title(r"$|\psi|$")
-            fig.colorbar(im0, ax=axes[0])
+        im0.set_data(np.abs(psi))
+        im1.set_data(tau)
+        line.set_data(np.arange(len(chi_history)), chi_history)
+        return im0, im1, line
 
-            im1 = axes[1].imshow(tau, origin="lower", cmap="plasma", vmin=1, vmax=collapse_threshold)
-            axes[1].set_title(r"$\tau$")
-            fig.colorbar(im1, ax=axes[1])
-
-            axes[2].plot(chi_history)
-            axes[2].set_xlim(0, timesteps)
-            axes[2].set_ylim(0, 1)
-            axes[2].set_title(r"$\chi$")
-
-            fig.tight_layout()
-            fig.savefig(f"frames/frame_{t:04d}.png")
-            plt.close(fig)
+    anim = FuncAnimation(fig, update, frames=timesteps, interval=50, blit=True)
+    fig.tight_layout()
+    return fig, anim
 
 
 if __name__ == "__main__":
-    run_simulation()
+    fig, _ = create_animation()
+    plt.show()

--- a/src/echofoam_falsifiability/teleportation.py
+++ b/src/echofoam_falsifiability/teleportation.py
@@ -2,97 +2,86 @@ import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.animation import FuncAnimation
 
-# Grid size and simulation steps
-size = 100
-steps = 150
 
-# Ring generation helper
-def ring_field(center, radius=10, thickness=2):
+def ring_field(center, radius=10, thickness=2, size=100):
     y, x = np.ogrid[:size, :size]
-    dist = np.sqrt((x - center[0])**2 + (y - center[1])**2)
-    return np.exp(-((dist - radius) / thickness)**2)
-
-# Initial psi blob at start location
-start_center = np.array([30.0, 50.0])
-psi_center = start_center.copy()
-psi = ring_field(psi_center)
-
-# Tau and chi fields
-tau = np.zeros((size, size))
-chi = np.zeros((size, size))
-
-# Teleportation target
-target_center = np.array([70.0, 50.0])
-teleport_start = 30
-teleport_complete = None
-
-# Visualization setup (tau, grad, psi, chi)
-fig, axes = plt.subplots(2, 2, figsize=(8, 8))
-im_tau = axes[0, 0].imshow(tau, cmap="plasma", vmin=-1, vmax=1, animated=True)
-axes[0, 0].set_title("tau")
-
-# placeholder gradient
-grad_x, grad_y = np.gradient(tau)
-grad_mag = np.sqrt(grad_x**2 + grad_y**2)
-im_grad = axes[0, 1].imshow(grad_mag, cmap="cividis", animated=True)
-axes[0, 1].set_title("∇tau")
-
-im_psi = axes[1, 0].imshow(psi, cmap="viridis", animated=True)
-axes[1, 0].set_title("psi")
-
-im_chi = axes[1, 1].imshow(chi, cmap="inferno", animated=True)
-axes[1, 1].set_title("chi")
-
-for row in axes:
-    for ax in row:
-        ax.set_xticks([])
-        ax.set_yticks([])
-
-step_size = 0.4  # movement sensitivity
+    dist = np.sqrt((x - center[0]) ** 2 + (y - center[1]) ** 2)
+    return np.exp(-((dist - radius) / thickness) ** 2)
 
 
-def update(frame):
-    global psi_center, psi, tau, chi, grad_x, grad_y, grad_mag, teleport_complete
+def create_animation():
+    size = 100
+    steps = 150
 
-    # Introduce negative shape at teleport_start
-    if frame == teleport_start:
-        tau -= ring_field(target_center)
+    start_center = np.array([30.0, 50.0])
+    psi_center = start_center.copy()
+    psi = ring_field(psi_center, size=size)
 
-    # Gradient of tau
+    tau = np.zeros((size, size))
+    chi = np.zeros((size, size))
+
+    target_center = np.array([70.0, 50.0])
+    teleport_start = 30
+    teleport_complete = None
+
+    fig, axes = plt.subplots(2, 2, figsize=(8, 8))
+    im_tau = axes[0, 0].imshow(tau, cmap="plasma", vmin=-1, vmax=1, animated=True)
+    axes[0, 0].set_title("tau")
+
     grad_x, grad_y = np.gradient(tau)
     grad_mag = np.sqrt(grad_x**2 + grad_y**2)
+    im_grad = axes[0, 1].imshow(grad_mag, cmap="cividis", animated=True)
+    axes[0, 1].set_title("∇tau")
 
-    # Move psi center according to gradient at its current location
-    g = np.array([
-        grad_x[int(psi_center[1]) % size, int(psi_center[0]) % size],
-        grad_y[int(psi_center[1]) % size, int(psi_center[0]) % size],
-    ])
-    psi_center -= step_size * g
-    psi = ring_field(psi_center)
+    im_psi = axes[1, 0].imshow(psi, cmap="viridis", animated=True)
+    axes[1, 0].set_title("psi")
 
-    # Simple chi wave tied to psi
-    chi[:] = np.sin(frame / 5.0) * psi
+    im_chi = axes[1, 1].imshow(chi, cmap="inferno", animated=True)
+    axes[1, 1].set_title("chi")
 
-    # Check teleport completion
-    if teleport_complete is None:
-        dist = np.linalg.norm(psi_center - target_center)
-        if dist < 1.0:
-            teleport_complete = frame
-            print(f"Teleportation completed at frame {frame} at {tuple(target_center.astype(int))}")
-            tau[:] = 0  # erase original
+    for row in axes:
+        for ax in row:
+            ax.set_xticks([])
+            ax.set_yticks([])
 
-    im_tau.set_data(tau)
-    im_grad.set_data(grad_mag)
-    im_psi.set_data(psi)
-    im_chi.set_data(chi)
+    step_size = 0.4
 
-    if frame == steps - 1:
-        plt.savefig("teleport.png")
+    def update(frame):
+        nonlocal psi_center, psi, tau, chi, grad_x, grad_y, grad_mag, teleport_complete
 
-    return im_tau, im_grad, im_psi, im_chi
+        if frame == teleport_start:
+            tau -= ring_field(target_center, size=size)
+
+        grad_x, grad_y = np.gradient(tau)
+        grad_mag = np.sqrt(grad_x**2 + grad_y**2)
+
+        g = np.array([
+            grad_x[int(psi_center[1]) % size, int(psi_center[0]) % size],
+            grad_y[int(psi_center[1]) % size, int(psi_center[0]) % size],
+        ])
+        psi_center -= step_size * g
+        psi = ring_field(psi_center, size=size)
+
+        chi[:] = np.sin(frame / 5.0) * psi
+
+        if teleport_complete is None:
+            dist = np.linalg.norm(psi_center - target_center)
+            if dist < 1.0:
+                teleport_complete = frame
+                tau[:] = 0
+
+        im_tau.set_data(tau)
+        im_grad.set_data(grad_mag)
+        im_psi.set_data(psi)
+        im_chi.set_data(chi)
+
+        return im_tau, im_grad, im_psi, im_chi
+
+    anim = FuncAnimation(fig, update, frames=steps, interval=50, blit=True, repeat=False)
+    plt.tight_layout()
+    return fig, anim
 
 
-ani = FuncAnimation(fig, update, frames=steps, interval=50, blit=True, repeat=False)
-plt.tight_layout()
-ani.save("teleport.mp4", writer="ffmpeg")
-plt.close(fig)
+if __name__ == "__main__":
+    fig, _ = create_animation()
+    plt.show()

--- a/src/echofoam_falsifiability/weather_simulation.py
+++ b/src/echofoam_falsifiability/weather_simulation.py
@@ -1,90 +1,69 @@
 import numpy as np
 import matplotlib.pyplot as plt
+from matplotlib.animation import FuncAnimation
 
-# Simulation parameters
-size = 50
-steps = 200
 
-# Fields
-# tau: temperature-pressure memory field
-np.random.seed(0)
-tau = np.random.randn(size, size) * 0.5
-# psi: coherent weather structures
-psi = np.zeros((size, size))
-# chi: reinforcement tracker
-chi = np.zeros((size, size))
+def create_animation():
+    size = 50
+    steps = 200
+    np.random.seed(0)
+    tau = np.random.randn(size, size) * 0.5
+    psi = np.zeros((size, size))
+    chi = np.zeros((size, size))
 
-# for visualization
-fig, axes = plt.subplots(2, 2, figsize=(8, 8))
-im_tau = axes[0, 0].imshow(tau, cmap='coolwarm', vmin=-2, vmax=2)
-axes[0, 0].set_title('tau')
+    fig, axes = plt.subplots(2, 2, figsize=(8, 8))
+    im_tau = axes[0, 0].imshow(tau, cmap='coolwarm', vmin=-2, vmax=2)
+    axes[0, 0].set_title('tau')
 
-# initial gradient
-grad_x, grad_y = np.gradient(tau)
-grad_mag = np.sqrt(grad_x**2 + grad_y**2)
-im_grad = axes[0, 1].imshow(grad_mag, cmap='viridis')
-axes[0, 1].set_title('∇tau')
-
-im_psi = axes[1, 0].imshow(psi, cmap='plasma', vmin=0, vmax=1)
-axes[1, 0].set_title('psi')
-
-im_chi = axes[1, 1].imshow(chi, cmap='inferno', vmin=0, vmax=1)
-axes[1, 1].set_title('chi')
-
-for ax_row in axes:
-    for ax in ax_row:
-        ax.set_xticks([])
-        ax.set_yticks([])
-
-frames_to_save = []
-
-for step in range(steps):
-    # random fluctuation with slight decay
-    tau += 0.05 * np.random.randn(size, size)
-    tau *= 0.99
-
-    # external influence at step 50: heat pulse at center
-    if step == 50:
-        pulse = np.zeros_like(tau)
-        cx = cy = size // 2
-        pulse[cx-2:cx+3, cy-2:cy+3] = 5.0
-        tau += pulse
-
-    # gradient
     grad_x, grad_y = np.gradient(tau)
     grad_mag = np.sqrt(grad_x**2 + grad_y**2)
+    im_grad = axes[0, 1].imshow(grad_mag, cmap='viridis')
+    axes[0, 1].set_title('∇tau')
 
-    # psi evolves toward regions of low gradient
-    psi += 0.1 * (1.0 / (1.0 + grad_mag) - psi)
-    psi = np.clip(psi, 0.0, 1.0)
+    im_psi = axes[1, 0].imshow(psi, cmap='plasma', vmin=0, vmax=1)
+    axes[1, 0].set_title('psi')
 
-    # chi reinforcement: increase where psi stable, decrease with high grad
-    stability = (psi > 0.6).astype(float)
-    chi += 0.05 * stability
-    chi -= 0.05 * (grad_mag > 1.5)
-    chi = np.clip(chi, 0.0, 1.0)
+    im_chi = axes[1, 1].imshow(chi, cmap='inferno', vmin=0, vmax=1)
+    axes[1, 1].set_title('chi')
 
-    # update images
-    im_tau.set_data(tau)
-    im_grad.set_data(grad_mag)
-    im_psi.set_data(psi)
-    im_chi.set_data(chi)
+    for ax_row in axes:
+        for ax in ax_row:
+            ax.set_xticks([])
+            ax.set_yticks([])
 
-    # save every 100th frame
-    if step % 100 == 0:
-        plt.savefig(f'frame_{step}.png')
-        frames_to_save.append(step)
+    def update(step):
+        nonlocal tau, psi, chi, grad_x, grad_y, grad_mag
+        tau += 0.05 * np.random.randn(size, size)
+        tau *= 0.99
 
-# save final visualization
-plt.tight_layout()
-plt.savefig('weather.png')
+        if step == 50:
+            pulse = np.zeros_like(tau)
+            cx = cy = size // 2
+            pulse[cx-2:cx+3, cy-2:cy+3] = 5.0
+            tau += pulse
 
-# prediction summary
-stable_regions = np.argwhere(psi > 0.6)
-collapsing_regions = np.argwhere(chi < 0.2)
-summary = f"Stable cells: {len(stable_regions)}\nCollapsing cells: {len(collapsing_regions)}"
-print(summary)
+        grad_x, grad_y = np.gradient(tau)
+        grad_mag = np.sqrt(grad_x**2 + grad_y**2)
 
-with open('weather_log.txt', 'w') as f:
-    f.write('Frames saved: ' + ', '.join(map(str, frames_to_save)) + '\n')
-    f.write(summary + '\n')
+        psi += 0.1 * (1.0 / (1.0 + grad_mag) - psi)
+        psi = np.clip(psi, 0.0, 1.0)
+
+        stability = (psi > 0.6).astype(float)
+        chi += 0.05 * stability
+        chi -= 0.05 * (grad_mag > 1.5)
+        chi = np.clip(chi, 0.0, 1.0)
+
+        im_tau.set_data(tau)
+        im_grad.set_data(grad_mag)
+        im_psi.set_data(psi)
+        im_chi.set_data(chi)
+        return im_tau, im_grad, im_psi, im_chi
+
+    anim = FuncAnimation(fig, update, frames=steps, interval=50, blit=False)
+    plt.tight_layout()
+    return fig, anim
+
+
+if __name__ == "__main__":
+    fig, _ = create_animation()
+    plt.show()

--- a/teleportation.py
+++ b/teleportation.py
@@ -1,0 +1,11 @@
+from echofoam_falsifiability.teleportation import create_animation as _create_animation
+
+
+def create_animation():
+    return _create_animation()
+
+
+if __name__ == "__main__":
+    import matplotlib.pyplot as plt
+    fig, anim = create_animation()
+    plt.show()

--- a/tests/sitecustomize.py
+++ b/tests/sitecustomize.py
@@ -1,0 +1,8 @@
+import sys
+from pathlib import Path
+root = Path(__file__).resolve().parents[1]
+src_pkg = root / 'src' / 'echofoam_falsifiability'
+if str(root) not in sys.path:
+    sys.path.insert(0, str(root))
+if src_pkg.exists() and str(src_pkg) not in sys.path:
+    sys.path.insert(0, str(src_pkg))

--- a/tests/test_blockchain_memory.py
+++ b/tests/test_blockchain_memory.py
@@ -1,4 +1,6 @@
 import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 import unittest
 from echofoam_falsifiability.blockchain_memory import BlockchainMemory
 

--- a/tests/test_simulations.py
+++ b/tests/test_simulations.py
@@ -1,3 +1,6 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 import unittest
 from matplotlib.figure import Figure
 from matplotlib.animation import FuncAnimation

--- a/weather_simulation.py
+++ b/weather_simulation.py
@@ -1,0 +1,11 @@
+from echofoam_falsifiability.weather_simulation import create_animation as _create_animation
+
+
+def create_animation():
+    return _create_animation()
+
+
+if __name__ == "__main__":
+    import matplotlib.pyplot as plt
+    fig, anim = create_animation()
+    plt.show()


### PR DESCRIPTION
## Summary
- turn each simulation into `create_animation()` returning `(fig, anim)`
- ensure animations only run when executed as scripts
- expose package path for imports
- provide lightweight wrappers for easier imports
- adjust tests to modify `sys.path`

## Testing
- `pytest -q`