### PR TITLE
Add game engine docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,6 @@ python -m echofoam_falsifiability.weather_sphere --radius 1.0 --theta 1.57 --phi
 ```
 Adjust the parameters to explore different sphere sizes, angular extents and terrain bumpiness.
 Use `--show` to display an updating 3D view. A final `weather_sphere.png` image is also saved.
+
+## Game Engine Prototype
+See [docs/game_engine.md](docs/game_engine.md) for a small Pygame-based demo. The `tension_game.py` script shows how "echofoam logic" can drive gameplay using a simple tension metric.

--- a/docs/game_engine.md
+++ b/docs/game_engine.md
@@ -1,0 +1,25 @@
+# Echofoam Logic Game Engine
+
+`tension_game.py` is a compact demonstration of an "echofoam logic" game engine using Pygame. The script runs a basic loop where the player's tension level affects game behavior.
+
+## Tension Mechanic
+- **Proximity based**: Tension rises when the player sprite approaches the enemy within `TENSION_RADIUS` pixels.
+- **Decay over time**: Each frame reduces tension by `TENSION_DECAY` so calm periods slowly reset the value.
+- **Gameplay effects**: Higher tension speeds up the enemy and darkens the screen, showing how a single parameter can drive multiple responses.
+
+## Requirements
+- Python 3.10+
+- `pygame`
+
+Install Pygame with:
+```bash
+pip install pygame
+```
+(Other packages used by the project can be installed from `environment.yml`.)
+
+## Running the Demo
+From the repository root, execute:
+```bash
+python tension_game.py
+```
+Use the arrow keys or WASD to move. Close the window or press ESC to exit.


### PR DESCRIPTION
## Summary
- document how tension_game demonstrates an echofoam logic engine
- provide instructions for running the demo
- link from README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'echofoam_falsifiability')*