### PR TITLE
Refactor animation modules and add wrappers

### DIFF
--- a/src/echofoam_falsifiability/laser_filamentation.py
+++ b/src/echofoam_falsifiability/laser_filamentation.py
@@ -57,6 +57,10 @@ def create_animation(grid_size=128, timesteps=400, alpha=0.01, beta=0.05,
     return fig, anim
 
 
-if __name__ == "__main__":
+def main():
     fig, _ = create_animation()
     plt.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/echofoam_falsifiability/simulation.py
+++ b/src/echofoam_falsifiability/simulation.py
@@ -6,104 +6,123 @@ from matplotlib.animation import FuncAnimation, FFMpegWriter
 size = 100
 steps = 200
 
-# Fields
-tau = np.random.randn(size, size) * 0.1  # initial tension field
-psi = np.zeros((size, size))             # coherence field
-chi = np.zeros((size, size))             # wave field
-chi_prev = np.zeros_like(chi)
-
-# Falsifiability parameters
-coherence_threshold = 0.8
-coherence_fraction = 0.6
-coherence_frames_required = 100
-consecutive_coherent = 0
-verdict = None
-verdict_step = None
-
-# Visualization setup for 2x2 grid
-fig, axes = plt.subplots(2, 2, figsize=(8, 8))
-im_tau = axes[0, 0].imshow(tau, cmap='plasma', animated=True)
-axes[0, 0].set_title('tau')
-
-grad_x, grad_y = np.gradient(tau)
-grad_mag = np.sqrt(grad_x**2 + grad_y**2)
-im_grad = axes[0, 1].imshow(grad_mag, cmap='cividis', animated=True)
-axes[0, 1].set_title('∇tau')
-
-im_psi = axes[1, 0].imshow(psi, cmap='viridis', animated=True)
-axes[1, 0].set_title('psi')
-im_chi = axes[1, 1].imshow(chi, cmap='inferno', animated=True)
-axes[1, 1].set_title('chi')
-
-for row in axes:
-    for ax in row:
-        ax.set_xticks([])
-        ax.set_yticks([])
+# Global state used during the animation
+_tau = None
+_psi = None
+_chi = None
+_chi_prev = None
+_grad_mag = None
+_consecutive_coherent = 0
+_verdict = None
+_verdict_step = None
 
 
-def update(frame):
-    global tau, psi, chi, chi_prev, grad_mag
-    global consecutive_coherent, verdict, verdict_step
-    # small random tension updates with damping
-    tau += 0.1 * np.random.randn(size, size)
-    tau *= 0.995
+def _init_fields():
+    """Initialize the simulation fields and globals."""
+    global _tau, _psi, _chi, _chi_prev, _grad_mag
+    global _consecutive_coherent, _verdict, _verdict_step
 
-    # gradient of tau
-    grad_x, grad_y = np.gradient(tau)
-    grad_mag = np.sqrt(grad_x**2 + grad_y**2)
+    _tau = np.random.randn(size, size) * 0.1
+    _psi = np.zeros((size, size))
+    _chi = np.zeros((size, size))
+    _chi_prev = np.zeros_like(_chi)
+    _grad_mag = np.zeros_like(_tau)
+    _consecutive_coherent = 0
+    _verdict = None
+    _verdict_step = None
 
-    # psi flows toward regions of low gradient magnitude
-    psi += 0.1 * (1.0 / (1.0 + grad_mag) - psi)
 
-    # propagate chi wave influenced by psi (simple discrete wave eq.)
-    laplacian = (
-        np.roll(chi, 1, axis=0) + np.roll(chi, -1, axis=0) +
-        np.roll(chi, 1, axis=1) + np.roll(chi, -1, axis=1) - 4 * chi
-    )
-    chi_new = 2 * chi - chi_prev + 0.2 * psi * laplacian
-    chi_prev = chi
-    chi = chi_new
+def create_animation():
+    """Construct the figure and animation for the simulation."""
+    _init_fields()
 
-    # falsifiability tracking
-    if verdict is None:
-        frac = np.mean(psi > coherence_threshold)
-        if frac >= coherence_fraction:
-            consecutive_coherent += 1
-            if consecutive_coherent >= coherence_frames_required:
-                verdict = "Hypothesis sustained"
-                verdict_step = frame
-                print(f"Coherence stabilized at step {frame}")
-        else:
-            if consecutive_coherent > 0:
-                verdict = "Hypothesis failed"
-                verdict_step = frame
-                print(f"Coherence lost at step {frame}")
-            consecutive_coherent = 0
+    fig, axes = plt.subplots(2, 2, figsize=(8, 8))
+    im_tau = axes[0, 0].imshow(_tau, cmap="plasma", animated=True)
+    axes[0, 0].set_title("tau")
 
-    im_tau.set_data(tau)
-    im_grad.set_data(grad_mag)
-    im_psi.set_data(psi)
-    im_chi.set_data(chi)
+    grad_x, grad_y = np.gradient(_tau)
+    global _grad_mag
+    _grad_mag = np.sqrt(grad_x**2 + grad_y**2)
+    im_grad = axes[0, 1].imshow(_grad_mag, cmap="cividis", animated=True)
+    axes[0, 1].set_title("∇tau")
 
-    # save final frame
-    if frame == steps - 1:
-        plt.savefig("final_frame.png")
+    im_psi = axes[1, 0].imshow(_psi, cmap="viridis", animated=True)
+    axes[1, 0].set_title("psi")
 
-    return im_tau, im_grad, im_psi, im_chi
+    im_chi = axes[1, 1].imshow(_chi, cmap="inferno", animated=True)
+    axes[1, 1].set_title("chi")
 
-ani = FuncAnimation(fig, update, frames=steps, interval=50, blit=True, repeat=False)
-plt.tight_layout()
+    for row in axes:
+        for ax in row:
+            ax.set_xticks([])
+            ax.set_yticks([])
 
-writer = FFMpegWriter(fps=20)
-ani.save("simulation.mp4", writer=writer)
+    def update(frame):
+        global _tau, _psi, _chi, _chi_prev, _grad_mag
+        global _consecutive_coherent, _verdict, _verdict_step
 
-if verdict is None:
-    verdict = "Hypothesis failed"
-    verdict_step = steps - 1
+        _tau += 0.1 * np.random.randn(size, size)
+        _tau *= 0.995
 
-with open("epcd_results.txt", "w") as f:
-    f.write(verdict + "\n")
+        grad_x, grad_y = np.gradient(_tau)
+        _grad_mag = np.sqrt(grad_x**2 + grad_y**2)
 
-print(verdict)
-plt.close(fig)
+        _psi += 0.1 * (1.0 / (1.0 + _grad_mag) - _psi)
 
+        laplacian = (
+            np.roll(_chi, 1, axis=0) + np.roll(_chi, -1, axis=0)
+            + np.roll(_chi, 1, axis=1) + np.roll(_chi, -1, axis=1)
+            - 4 * _chi
+        )
+        chi_new = 2 * _chi - _chi_prev + 0.2 * _psi * laplacian
+        _chi_prev = _chi
+        _chi = chi_new
+
+        if _verdict is None:
+            frac = np.mean(_psi > 0.8)
+            if frac >= 0.6:
+                _consecutive_coherent += 1
+                if _consecutive_coherent >= 100:
+                    _verdict = "Hypothesis sustained"
+                    _verdict_step = frame
+                    print(f"Coherence stabilized at step {frame}")
+            else:
+                if _consecutive_coherent > 0:
+                    _verdict = "Hypothesis failed"
+                    _verdict_step = frame
+                    print(f"Coherence lost at step {frame}")
+                _consecutive_coherent = 0
+
+        im_tau.set_data(_tau)
+        im_grad.set_data(_grad_mag)
+        im_psi.set_data(_psi)
+        im_chi.set_data(_chi)
+
+        if frame == steps - 1:
+            plt.savefig("final_frame.png")
+        return im_tau, im_grad, im_psi, im_chi
+
+    anim = FuncAnimation(fig, update, frames=steps, interval=50, blit=True, repeat=False)
+    plt.tight_layout()
+    return fig, anim
+
+
+def main():
+    fig, anim = create_animation()
+    writer = FFMpegWriter(fps=20)
+    anim.save("simulation.mp4", writer=writer)
+
+    global _verdict, _verdict_step
+    if _verdict is None:
+        _verdict = "Hypothesis failed"
+        _verdict_step = steps - 1
+
+    with open("epcd_results.txt", "w") as f:
+        f.write(_verdict + "\n")
+
+    print(_verdict)
+    plt.close(fig)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/echofoam_falsifiability/teleportation.py
+++ b/src/echofoam_falsifiability/teleportation.py
@@ -82,6 +82,10 @@ def create_animation():
     return fig, anim
 
 
-if __name__ == "__main__":
+def main():
     fig, _ = create_animation()
     plt.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/echofoam_falsifiability/weather_simulation.py
+++ b/src/echofoam_falsifiability/weather_simulation.py
@@ -64,6 +64,10 @@ def create_animation():
     return fig, anim
 
 
-if __name__ == "__main__":
+def main():
     fig, _ = create_animation()
     plt.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/laser_filamentation.py
+++ b/src/laser_filamentation.py
@@ -1,0 +1,10 @@
+from echofoam_falsifiability.laser_filamentation import create_animation, main as _main
+
+__all__ = ["create_animation", "main"]
+
+def main():
+    _main()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/simulation.py
+++ b/src/simulation.py
@@ -1,0 +1,10 @@
+from echofoam_falsifiability.simulation import create_animation, main as _main
+
+__all__ = ["create_animation", "main"]
+
+def main():
+    _main()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/teleportation.py
+++ b/src/teleportation.py
@@ -1,0 +1,10 @@
+from echofoam_falsifiability.teleportation import create_animation, main as _main
+
+__all__ = ["create_animation", "main"]
+
+def main():
+    _main()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/weather_simulation.py
+++ b/src/weather_simulation.py
@@ -1,0 +1,10 @@
+from echofoam_falsifiability.weather_simulation import create_animation, main as _main
+
+__all__ = ["create_animation", "main"]
+
+def main():
+    _main()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- refactor `src/echofoam_falsifiability/simulation.py` into `create_animation`/`main`
- add `main` entrypoints to other simulation modules
- expose wrapper modules in `src/` for tests

## Testing
- `PYTHONPATH=src pytest -q`