### PR TITLE
Add pygame to environment

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,3 +10,4 @@ dependencies:
   - moviepy
   - ffmpeg
   - pytest
+  - pygame

--- a/tests/environment.yml
+++ b/tests/environment.yml
@@ -10,3 +10,4 @@ dependencies:
   - pip
   - pip:
       - echofoam-falsifiability-suite
+  - pygame


### PR DESCRIPTION
## Summary
- include pygame in default environment
- add pygame for test environments

## Testing
- `pytest -q` *(fails: laser_filamentation.create_animation does not exist)*