### PR TITLE
Revamp repository around falsifiable mechanism assays

### DIFF
--- a/.github/workflows/scientific-assays.yml
+++ b/.github/workflows/scientific-assays.yml
@@ -13,6 +13,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
     steps:

--- a/.github/workflows/scientific-assays.yml
+++ b/.github/workflows/scientific-assays.yml
@@ -1,0 +1,26 @@
+name: Scientific assay checks
+
+on:
+  push:
+    branches: ["main", "revamp/**"]
+  pull_request:
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - run: python -m pip install --upgrade pip
+      - run: python -m pip install -e ".[test]"
+      - run: pytest

--- a/.gitignore
+++ b/.gitignore
@@ -26,16 +26,6 @@ share/python-wheels/
 *.egg
 MANIFEST
 
-# PyInstaller
-#  Usually these files are written by a python script from a template
-#  before PyInstaller builds the exe, so as to inject date/other infos into it.
-*.manifest
-*.spec
-
-# Installer logs
-pip-log.txt
-pip-delete-this-directory.txt
-
 # Unit test / coverage reports
 htmlcov/
 .tox/
@@ -51,125 +41,30 @@ coverage.xml
 .pytest_cache/
 cover/
 
-# Translations
-*.mo
-*.pot
-
-# Django stuff:
-*.log
-local_settings.py
-db.sqlite3
-db.sqlite3-journal
-
-# Flask stuff:
-instance/
-.webassets-cache
-
-# Scrapy stuff:
-.scrapy
-
-# Sphinx documentation
-docs/_build/
-
-# PyBuilder
-.pybuilder/
-target/
-
-# Jupyter Notebook
-.ipynb_checkpoints
-
-# IPython
-profile_default/
-ipython_config.py
-
-# pyenv
-#   For a library or package, you might want to ignore these files since the code is
-#   intended to run in multiple environments; otherwise, check them in:
-# .python-version
-
-# pipenv
-#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
-#   However, in case of collaboration, if having platform-specific dependencies or dependencies
-#   having no cross-platform support, pipenv may install dependencies that don't work, or not
-#   install all needed dependencies.
-#Pipfile.lock
-
-# UV
-#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
-#   This is especially recommended for binary packages to ensure reproducibility, and is more
-#   commonly ignored for libraries.
-#uv.lock
-
-# poetry
-#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
-#   This is especially recommended for binary packages to ensure reproducibility, and is more
-#   commonly ignored for libraries.
-#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
-#poetry.lock
-
-# pdm
-#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
-#pdm.lock
-#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
-#   in version control.
-#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
-.pdm.toml
-.pdm-python
-.pdm-build/
-
-# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
-__pypackages__/
-
-# Celery stuff
-celerybeat-schedule
-celerybeat.pid
-
-# SageMath parsed files
-*.sage.py
-
 # Environments
 .env
-.venv
+.venv/
 env/
 venv/
 ENV/
 env.bak/
 venv.bak/
 
-# Spyder project settings
-.spyderproject
-.spyproject
-
-# Rope project settings
-.ropeproject
-
-# mkdocs documentation
-/site
-
-# mypy
+# Tool caches
+.ipynb_checkpoints/
 .mypy_cache/
-.dmypy.json
-dmypy.json
-
-# Pyre type checker
-.pyre/
-
-# pytype static type analyzer
-.pytype/
-
-# Cython debug symbols
-cython_debug/
-
-# PyCharm
-#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
-#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
-#  and can be added to the global gitignore or merged into this file.  For a more nuclear
-#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
-
-# Ruff stuff:
 .ruff_cache/
 
-# PyPI configuration file
-.pypirc
-Samples
+# Generated scientific assay artifacts
+audit_output/
+smoke_output/
+*.mp4
+frame_*.png
+final_frame.png
+epcd_results.txt
+test_chain.json
+
+# OS and editor
+.DS_Store
+.idea/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -1,64 +1,54 @@
-# Echofoam-Falsifiability-suite
-Scientific challenge suite for testing Echofoam Theory (emergent c, BAOs, redshift)
-# Echofoam Falsifiability Suite
-## 🔗 Cite This Release
-
-## 📌 Cite This Release
+# Falsifiable Coherence and Memory Assays
 
 [![DOI](https://zenodo.org/badge/961712182.svg)](https://doi.org/10.5281/zenodo.15505391)
 
-> Lorello, James. *Echofoam Falsifiability Suite v1.0*. Zenodo.  
+This repository preserves the historical **Echofoam Falsifiability Suite** while rebuilding it as a mechanism-first collection of reproducible numerical assays.
+
+## Scientific status
+
+This codebase is a sandbox for testing explicit dynamical mechanisms. It is not a validated theory of cosmology, gravity, consciousness, dark matter, or dark energy.
+
+| Item | Current status |
+| --- | --- |
+| Legacy animation suite | Demonstration code; does not discriminate physical hypotheses |
+| Emergent propagation speed vCF-1.1 | Falsified: measured speed about 0.3559 versus prediction 1 |
+| Legacy BAO-like visual outputs | Unverified until raw outputs and matched controls are recovered |
+| Delayed-memory pattern claim | Retired by matched controls; behavior is consistent with diffusion and box-scale coarsening |
+| Ledger/fatigue separation | Toy-model behavior, internally testable, physical interpretation unresolved |
+| Present-gated history effect | Open; counts only if the gate emerges from local dynamics |
+
+See [Scientific Status](docs/SCIENTIFIC_STATUS.md) for the evidence boundary and [Repository Map](docs/REPOSITORY_MAP.md) for the migration plan.
+
+## Canonical assay
+
+The first canonical assay compares delayed memory against:
+
+- no memory,
+- shuffled memory,
+- instantaneous feedback.
+
+It reports boundedness, variance survival, dominant spectral scale, spectral entropy, and paired branch differences. A memory-field correlation is never treated by itself as evidence that memory generated structure.
+
+```bash
+python -m pip install -e ".[test]"
+python -m echofoam_falsifiability.memory_coupling_audit --runs 24 --steps 1200
+pytest
+```
+
+Outputs are written to `audit_output/runs.csv` and `audit_output/summary.json`.
+
+## Repository policy
+
+- `src/echofoam_falsifiability/` is the only canonical Python package.
+- Root-level scripts and duplicate modules are retained temporarily as legacy material.
+- Tests must evaluate observables or invariants, not merely whether a visualization opens.
+- Every claimed mechanism needs matched null, shuffled, ablated, or instantaneous controls.
+- Raw results, parameters, seeds, code revision, and analysis criteria must travel together.
+- Negative results and falsified versions remain part of the record.
+
+## Historical citation
+
+Lorello, James. *Echofoam Falsifiability Suite v1.0*. Zenodo.  
 DOI: [10.5281/zenodo.15505391](https://doi.org/10.5281/zenodo.15505391)
 
-This repository contains a simplified simulation framework designed to test the Echofoam Theory of cosmological structure formation.
-
-**Purpose:**  
-To allow open, scientific attempts to *falsify* the theory by evaluating its predictions under clean, documented conditions.
-
-**Included Tests:**
-- Emergent `c` (causality propagation without injected constants)
-- BAO ring emergence via foam burst tension
-- Redshift via tension drag ("Echoshift")
-
-**Why?**  
-If Echofoam holds up to scrutiny, it may offer a new pathway to understanding cosmic memory, emergence, and tension as foundational to structure.
-
-## Getting Started
-
-1. Install requirements
-```bash
-pip install numpy matplotlib
-```
-
-2. Run the Tkinter viewer to visualize the tension-based interface. Tkinter is bundled with Python on many systems (on some Linux distributions you may need to install `python3-tk`). Use the command:
-```bash
-python adaptive_gui.py
-```
-
-3. Run the simulation or use the blockchain memory module as needed.
-
-## Blockchain Memory Scaffold
-
-The file `blockchain_memory.py` implements a minimal compressed memory chain where each entry references the previous block via its hash. The chain is saved to disk for persistence.
-
-### Example
-```python
-from blockchain_memory import BlockchainMemory
-
-mem = BlockchainMemory("demo_chain.json")
-block = mem.add_memory("an important observation")
-print(block.hash)
-```
-
-## Weather Sphere Simulation
-The module `weather_sphere.py` provides a simple 3D fluid field in spherical coordinates. It models the atmosphere as a thin shell above a bumpy terrain and visualizes a slice of the final temperature-pressure field.
-
-### Usage
-```bash
-python -m echofoam_falsifiability.weather_sphere --radius 1.0 --theta 1.57 --phi 6.28 --bump 0.05 --steps 200 --show
-```
-Adjust the parameters to explore different sphere sizes, angular extents and terrain bumpiness.
-Use `--show` to display an updating 3D view. A final `weather_sphere.png` image is also saved.
-
-## Game Engine Prototype
-See [docs/game_engine.md](docs/game_engine.md) for a small Pygame-based demo. The `tension_game.py` script shows how "echofoam logic" can drive gameplay using a simple tension metric.
+The DOI refers to the historical release. Claims in that release should be read with the status qualifications in this repository.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This codebase is a sandbox for testing explicit dynamical mechanisms. It is not 
 | Legacy animation suite | Demonstration code; does not discriminate physical hypotheses |
 | Emergent propagation speed vCF-1.1 | Falsified: measured speed about 0.3559 versus prediction 1 |
 | Legacy BAO-like visual outputs | Unverified until raw outputs and matched controls are recovered |
-| Delayed-memory pattern claim | Retired by matched controls; behavior is consistent with diffusion and box-scale coarsening |
+| Delayed-memory pattern claim | Not reproduced by the current reconstruction; confirmatory status remains inconclusive |
 | Ledger/fatigue separation | Toy-model behavior, internally testable, physical interpretation unresolved |
 | Present-gated history effect | Open; counts only if the gate emerges from local dynamics |
 
@@ -28,6 +28,8 @@ The first canonical assay compares delayed memory against:
 - instantaneous feedback.
 
 It reports boundedness, variance survival, dominant spectral scale, spectral entropy, and paired branch differences. A memory-field correlation is never treated by itself as evidence that memory generated structure.
+
+The current analysis is exploratory. Its paired medians do not supply a significance test, uncertainty interval, or preregistered material-effect threshold, so they cannot by themselves retire a mechanism.
 
 ```bash
 python -m pip install -e ".[test]"

--- a/docs/REPOSITORY_MAP.md
+++ b/docs/REPOSITORY_MAP.md
@@ -29,3 +29,5 @@ Game, weather, laser, teleportation, art, GUI, and blockchain prototypes are pre
 7. Tag a new release only after CI reproduces the canonical assays.
 
 No historical file should be silently erased because a failed version is evidence about the development path.
+
+The inventory must record `old_path`, `retained_path`, content hash, import users, associated claim, and last historical commit. Before relocation, legacy imports receive either a compatibility wrapper with a deprecation notice or a documented breaking-change decision. A duplicate is eligible for deletion only after this mapping is committed and its retained copy is verified.

--- a/docs/REPOSITORY_MAP.md
+++ b/docs/REPOSITORY_MAP.md
@@ -1,0 +1,31 @@
+# Repository Map and Migration Plan
+
+## Canonical
+
+- `src/echofoam_falsifiability/`: maintained package code.
+- `tests/`: behavioral, numerical, and scientific-regression tests.
+- `docs/`: scientific status, assay definitions, and archived interpretations.
+- `.github/workflows/`: reproducibility checks.
+
+## Legacy and pending classification
+
+The repository currently contains duplicate modules at:
+
+- repository root,
+- `src/`,
+- `src/echofoam_falsifiability/`,
+- a root compatibility package.
+
+Game, weather, laser, teleportation, art, GUI, and blockchain prototypes are preserved because they are part of the development history. They are not presently part of the scientific evidence suite.
+
+## Migration phases
+
+1. Establish honest status documents and a canonical matched-control assay.
+2. Inventory every legacy module by hash, dependency, output, and stated claim.
+3. Move unique historical prototypes under `legacy/` without rewriting their content.
+4. Delete only byte-identical duplicates after their commit history is recorded.
+5. Replace animation-instantiation tests with invariant and discriminator tests.
+6. Attach result manifests containing seed, parameters, environment, commit SHA, and preregistered observable.
+7. Tag a new release only after CI reproduces the canonical assays.
+
+No historical file should be silently erased because a failed version is evidence about the development path.

--- a/docs/SCIENTIFIC_STATUS.md
+++ b/docs/SCIENTIFIC_STATUS.md
@@ -1,0 +1,38 @@
+# Scientific Status
+
+## Evidence labels
+
+- **Reproduced:** executable code and saved outputs reproduce the stated result.
+- **Internal toy behavior:** reproducible inside the constructed model, without a physical identification.
+- **Inconclusive:** the observable, controls, or retained data are insufficient.
+- **Falsified:** a preregistered or explicit prediction failed.
+- **Unrecoverable:** a numerical claim survives only in prose.
+- **Speculative:** no discriminating assay has been completed.
+
+## Current ledger
+
+### Propagation speed
+
+The vCF-1.1 prediction assigned an emergent speed of 1. The measured value was about 0.3559. Status: **falsified for that version**.
+
+### Legacy memory-pattern simulation
+
+The stored `Echofoamsim.txt` contained damaged code and prose claiming a 38.7% resonant fraction. No corresponding JSON results, plots, or output directory were recovered. A conservative reconstruction compared delayed memory, no memory, shuffled memory, and instantaneous feedback over 24 matched seeds.
+
+All branches selected the lowest nonzero box mode. The field retained roughly 1.1e-5 of its initial variance. Delayed memory raised field correlation but did not materially change scale, spectral concentration, entropy, or variance survival. Status: **the memory-generated pattern claim is retired; tracking behavior is internally reproduced**.
+
+### BAO-like features
+
+Visual or spectral resemblance to BAO is not sufficient. Required controls include box-size and resolution scaling, null spectra, fixed analysis criteria, frozen parameters, and comparison with established matter-power observables. Status: **unverified**.
+
+### Ledger and fatigue
+
+Separated branches are a methodological improvement because contributions can fail independently. Reported loop behavior remains a property of a toy model. Status: **internal toy behavior**.
+
+### Present-gated history
+
+A history-dependent effect counts only when the present gate emerges from local dynamics. The update rule may not contain the evaluation score, global overlap, or an equivalent hand-coded gate. Status: **open**.
+
+## Interpretation boundary
+
+A successful code run establishes execution. A conserved numerical quantity establishes implementation bookkeeping. A correlation establishes association inside the model. None of these alone establishes a new physical field or law.

--- a/docs/SCIENTIFIC_STATUS.md
+++ b/docs/SCIENTIFIC_STATUS.md
@@ -19,7 +19,9 @@ The vCF-1.1 prediction assigned an emergent speed of 1. The measured value was a
 
 The stored `Echofoamsim.txt` contained damaged code and prose claiming a 38.7% resonant fraction. No corresponding JSON results, plots, or output directory were recovered. A conservative reconstruction compared delayed memory, no memory, shuffled memory, and instantaneous feedback over 24 matched seeds.
 
-All branches selected the lowest nonzero box mode. The field retained roughly 1.1e-5 of its initial variance. Delayed memory raised field correlation but did not materially change scale, spectral concentration, entropy, or variance survival. Status: **the memory-generated pattern claim is retired; tracking behavior is internally reproduced**.
+In the repaired reconstruction run, all branches selected the lowest nonzero box mode. Delayed memory raised field correlation without an obvious paired separation in scale, spectral concentration, entropy, or variance survival. The assay reports paired medians but has no confirmatory uncertainty calculation or preregistered material-effect threshold. Status: **not reproduced by this reconstruction; confirmatory status remains inconclusive**.
+
+The shuffled control uses the same zero-initialized delayed-memory update as the full branch, followed by one fixed spatial permutation. This preserves temporal filtering and marginal values while removing pointwise spatial correspondence. Re-permuting independently at every step would add temporal noise and would not be a matched control.
 
 ### BAO-like features
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,29 @@
+[build-system]
+requires = ["setuptools>=69", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "echofoam-falsifiability-suite"
+version = "0.2.0.dev0"
+description = "Mechanism-first numerical assays for coherence, memory, and correction dynamics"
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "MIT" }
+authors = [{ name = "James Lorello" }]
+dependencies = [
+  "numpy>=1.24",
+  "matplotlib>=3.7",
+]
+
+[project.optional-dependencies]
+test = ["pytest>=8"]
+
+[project.scripts]
+memory-coupling-audit = "echofoam_falsifiability.memory_coupling_audit:main"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-ra"

--- a/src/echofoam_falsifiability/memory_coupling_audit.py
+++ b/src/echofoam_falsifiability/memory_coupling_audit.py
@@ -5,12 +5,15 @@ from __future__ import annotations
 import argparse
 import csv
 import json
+import os
+import platform
 from dataclasses import asdict, dataclass
 from pathlib import Path
 
 import numpy as np
 
 BRANCHES = ("full_memory", "no_memory", "shuffled_memory", "instant_feedback")
+METRICS = ("prominence", "k_star", "spectral_entropy", "variance_ratio")
 
 
 @dataclass(frozen=True)
@@ -55,6 +58,10 @@ def div_psi_grad_tau(psi: np.ndarray, tau: np.ndarray, dx: float) -> np.ndarray:
 
 
 def radial_metrics(field: np.ndarray, dx: float) -> dict[str, float]:
+    if field.ndim != 2 or field.shape[0] != field.shape[1]:
+        raise ValueError("radial_metrics requires a square two-dimensional field")
+    if dx <= 0:
+        raise ValueError("dx must be positive")
     centered = field - np.mean(field)
     power = np.abs(np.fft.fft2(centered)) ** 2
     n = field.shape[0]
@@ -91,7 +98,10 @@ def simulate(
 ) -> dict[str, float | bool | str]:
     psi, tau = psi0.copy(), tau0.copy()
     memory = np.zeros_like(psi)
-    shuffled = rng.permutation(psi0.ravel()).reshape(psi0.shape)
+    # The shuffled branch uses the same zero-initialized, delayed memory field as
+    # the full branch. A single fixed permutation removes spatial correspondence
+    # while preserving its marginal values and temporal filtering.
+    shuffle_index = rng.permutation(psi.size)
     decay = np.log(2.0) / params.memory_half_life
     initial_variance = float(np.var(psi))
     bounded = True
@@ -101,8 +111,8 @@ def simulate(
             memory += dt * decay * (psi - memory)
             target, coupling = memory, params.memory_strength
         elif branch == "shuffled_memory":
-            shuffled += dt * decay * (psi - shuffled)
-            target = rng.permutation(shuffled.ravel()).reshape(psi.shape)
+            memory += dt * decay * (psi - memory)
+            target = memory.ravel()[shuffle_index].reshape(psi.shape)
             coupling = params.memory_strength
         elif branch == "instant_feedback":
             target, coupling = psi, params.memory_strength
@@ -156,6 +166,14 @@ def run_assay(
     dx: float = 1.0,
     seed: int = 50,
 ) -> tuple[list[dict], dict]:
+    if runs < 1:
+        raise ValueError("runs must be at least 1")
+    if steps < 1:
+        raise ValueError("steps must be at least 1")
+    if size < 4:
+        raise ValueError("size must be at least 4")
+    if dt <= 0 or dx <= 0:
+        raise ValueError("dt and dx must be positive")
     rows: list[dict] = []
     for run in range(runs):
         parameter_seed = seed + run
@@ -172,7 +190,21 @@ def run_assay(
                 **simulate(params, branch, psi0, tau0, branch_rng, steps=steps, dt=dt, dx=dx),
             })
 
-    summary: dict[str, dict] = {}
+    summary: dict[str, dict] = {
+        "assay_manifest": {
+            "runs": runs,
+            "steps": steps,
+            "size": size,
+            "dt": dt,
+            "dx": dx,
+            "seed": seed,
+            "branches": list(BRANCHES),
+            "python_version": platform.python_version(),
+            "numpy_version": np.__version__,
+            "commit_sha": os.environ.get("GITHUB_SHA", "unrecorded"),
+            "analysis_status": "exploratory; no confirmatory threshold is applied",
+        }
+    }
     for branch in BRANCHES:
         selected = [row for row in rows if row["branch"] == branch and row["bounded"]]
         summary[branch] = {"runs": runs, "bounded_fraction": len(selected) / runs}
@@ -187,7 +219,7 @@ def run_assay(
     for control in BRANCHES[1:]:
         control_rows = {row["run"]: row for row in rows if row["branch"] == control}
         paired[control] = {}
-        for metric in ("prominence", "k_star", "spectral_entropy", "variance_ratio"):
+        for metric in METRICS:
             deltas = [full[i][metric] - control_rows[i][metric] for i in full]
             paired[control][f"median_full_minus_control_{metric}"] = float(np.nanmedian(deltas))
     summary["paired_comparisons"] = paired

--- a/src/echofoam_falsifiability/memory_coupling_audit.py
+++ b/src/echofoam_falsifiability/memory_coupling_audit.py
@@ -1,0 +1,235 @@
+"""Matched-control assay for delayed memory and spatial pattern claims."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+import numpy as np
+
+BRANCHES = ("full_memory", "no_memory", "shuffled_memory", "instant_feedback")
+
+
+@dataclass(frozen=True)
+class Parameters:
+    diffusion_psi: float
+    beta: float
+    diffusion_tau: float
+    memory_strength: float
+    memory_half_life: float
+    a: float
+    b: float
+
+
+def sample_parameters(rng: np.random.Generator) -> Parameters:
+    return Parameters(
+        diffusion_psi=float(rng.uniform(0.1, 1.0)),
+        beta=float(rng.uniform(0.0, 1.0)),
+        diffusion_tau=float(rng.uniform(0.1, 1.0)),
+        memory_strength=float(rng.uniform(0.1, 1.0)),
+        memory_half_life=float(rng.uniform(10.0, 50.0)),
+        a=float(rng.uniform(-1.0, 1.0)),
+        b=float(rng.uniform(0.1, 1.0)),
+    )
+
+
+def laplacian(field: np.ndarray, dx: float) -> np.ndarray:
+    return (
+        np.roll(field, 1, 0) + np.roll(field, -1, 0)
+        + np.roll(field, 1, 1) + np.roll(field, -1, 1)
+        - 4.0 * field
+    ) / dx**2
+
+
+def div_psi_grad_tau(psi: np.ndarray, tau: np.ndarray, dx: float) -> np.ndarray:
+    grad_x = (np.roll(tau, -1, 1) - np.roll(tau, 1, 1)) / (2.0 * dx)
+    grad_y = (np.roll(tau, -1, 0) - np.roll(tau, 1, 0)) / (2.0 * dx)
+    flux_x, flux_y = psi * grad_x, psi * grad_y
+    return (
+        np.roll(flux_x, -1, 1) - np.roll(flux_x, 1, 1)
+        + np.roll(flux_y, -1, 0) - np.roll(flux_y, 1, 0)
+    ) / (2.0 * dx)
+
+
+def radial_metrics(field: np.ndarray, dx: float) -> dict[str, float]:
+    centered = field - np.mean(field)
+    power = np.abs(np.fft.fft2(centered)) ** 2
+    n = field.shape[0]
+    freq = np.fft.fftfreq(n, d=dx)
+    kx, ky = np.meshgrid(freq, freq)
+    bins = np.floor(np.sqrt(kx**2 + ky**2) / (1.0 / (n * dx))).astype(int)
+    sums = np.bincount(bins.ravel(), weights=power.ravel())
+    counts = np.bincount(bins.ravel())
+    radial = np.divide(sums, counts, out=np.zeros_like(sums), where=counts > 0)
+    nonzero = radial[1:]
+    if nonzero.size < 2 or np.sum(nonzero) <= 0:
+        return {"k_star": 0.0, "prominence": 0.0, "spectral_entropy": 0.0}
+    peak = int(np.argmax(nonzero)) + 1
+    probabilities = nonzero / np.sum(nonzero)
+    entropy = -np.sum(probabilities * np.log(probabilities + 1e-30))
+    entropy /= np.log(len(probabilities))
+    return {
+        "k_star": float(peak / (n * dx)),
+        "prominence": float(radial[peak] / (np.mean(nonzero) + 1e-30)),
+        "spectral_entropy": float(entropy),
+    }
+
+
+def simulate(
+    params: Parameters,
+    branch: str,
+    psi0: np.ndarray,
+    tau0: np.ndarray,
+    rng: np.random.Generator,
+    *,
+    steps: int,
+    dt: float,
+    dx: float,
+) -> dict[str, float | bool | str]:
+    psi, tau = psi0.copy(), tau0.copy()
+    memory = np.zeros_like(psi)
+    shuffled = rng.permutation(psi0.ravel()).reshape(psi0.shape)
+    decay = np.log(2.0) / params.memory_half_life
+    initial_variance = float(np.var(psi))
+    bounded = True
+
+    for _ in range(steps):
+        if branch == "full_memory":
+            memory += dt * decay * (psi - memory)
+            target, coupling = memory, params.memory_strength
+        elif branch == "shuffled_memory":
+            shuffled += dt * decay * (psi - shuffled)
+            target = rng.permutation(shuffled.ravel()).reshape(psi.shape)
+            coupling = params.memory_strength
+        elif branch == "instant_feedback":
+            target, coupling = psi, params.memory_strength
+        elif branch == "no_memory":
+            target, coupling = tau, 0.0
+        else:
+            raise ValueError(f"unknown branch: {branch}")
+
+        psi_dot = (
+            params.diffusion_psi * laplacian(psi, dx)
+            - (params.a * psi + params.b * psi**3)
+            + params.beta * div_psi_grad_tau(psi, tau, dx)
+        )
+        tau_dot = params.diffusion_tau * laplacian(tau, dx) + coupling * (target - tau)
+        psi += dt * psi_dot
+        tau += dt * tau_dot
+
+        if not (np.all(np.isfinite(psi)) and np.all(np.isfinite(tau))):
+            bounded = False
+            break
+        if max(float(np.max(np.abs(psi))), float(np.max(np.abs(tau)))) > 1e4:
+            bounded = False
+            break
+
+    metrics = radial_metrics(psi, dx) if bounded else {
+        "k_star": float("nan"),
+        "prominence": float("nan"),
+        "spectral_entropy": float("nan"),
+    }
+    final_variance = float(np.var(psi)) if bounded else float("nan")
+    correlation = 0.0
+    if bounded and np.std(psi) > 0 and np.std(tau) > 0:
+        correlation = float(np.corrcoef(psi.ravel(), tau.ravel())[0, 1])
+    return {
+        "branch": branch,
+        "bounded": bounded,
+        "initial_variance": initial_variance,
+        "final_variance": final_variance,
+        "variance_ratio": final_variance / (initial_variance + 1e-30),
+        "psi_tau_corr": correlation,
+        **metrics,
+    }
+
+
+def run_assay(
+    *,
+    runs: int = 24,
+    steps: int = 1200,
+    size: int = 64,
+    dt: float = 0.02,
+    dx: float = 1.0,
+    seed: int = 50,
+) -> tuple[list[dict], dict]:
+    rows: list[dict] = []
+    for run in range(runs):
+        parameter_seed = seed + run
+        rng = np.random.default_rng(parameter_seed)
+        params = sample_parameters(rng)
+        psi0 = rng.normal(0.0, 0.1, (size, size))
+        tau0 = rng.normal(0.0, 0.1, (size, size))
+        for branch_index, branch in enumerate(BRANCHES):
+            branch_rng = np.random.default_rng(parameter_seed * 100 + branch_index)
+            rows.append({
+                "run": run,
+                "parameter_seed": parameter_seed,
+                **asdict(params),
+                **simulate(params, branch, psi0, tau0, branch_rng, steps=steps, dt=dt, dx=dx),
+            })
+
+    summary: dict[str, dict] = {}
+    for branch in BRANCHES:
+        selected = [row for row in rows if row["branch"] == branch and row["bounded"]]
+        summary[branch] = {"runs": runs, "bounded_fraction": len(selected) / runs}
+        for metric in ("prominence", "k_star", "spectral_entropy", "variance_ratio", "psi_tau_corr"):
+            values = np.asarray([row[metric] for row in selected], dtype=float)
+            summary[branch][f"median_{metric}"] = (
+                float(np.nanmedian(values)) if values.size else None
+            )
+
+    full = {row["run"]: row for row in rows if row["branch"] == "full_memory"}
+    paired = {}
+    for control in BRANCHES[1:]:
+        control_rows = {row["run"]: row for row in rows if row["branch"] == control}
+        paired[control] = {}
+        for metric in ("prominence", "k_star", "spectral_entropy", "variance_ratio"):
+            deltas = [full[i][metric] - control_rows[i][metric] for i in full]
+            paired[control][f"median_full_minus_control_{metric}"] = float(np.nanmedian(deltas))
+    summary["paired_comparisons"] = paired
+
+    box_mode = 1.0 / (size * dx)
+    summary["audit_diagnostics"] = {
+        "lowest_nonzero_box_mode": box_mode,
+        "full_branch_peak_is_box_mode": bool(
+            np.isclose(summary["full_memory"]["median_k_star"], box_mode)
+        ),
+        "interpretation_guard": (
+            "A memory-specific effect requires paired separation from controls. "
+            "Correlation alone establishes tracking inside the toy model."
+        ),
+    }
+    return rows, summary
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--runs", type=int, default=24)
+    parser.add_argument("--steps", type=int, default=1200)
+    parser.add_argument("--size", type=int, default=64)
+    parser.add_argument("--dt", type=float, default=0.02)
+    parser.add_argument("--dx", type=float, default=1.0)
+    parser.add_argument("--seed", type=int, default=50)
+    parser.add_argument("--output", type=Path, default=Path("audit_output"))
+    args = parser.parse_args()
+
+    rows, summary = run_assay(
+        runs=args.runs, steps=args.steps, size=args.size,
+        dt=args.dt, dx=args.dx, seed=args.seed,
+    )
+    args.output.mkdir(parents=True, exist_ok=True)
+    with (args.output / "runs.csv").open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(rows[0]))
+        writer.writeheader()
+        writer.writerows(rows)
+    with (args.output / "summary.json").open("w", encoding="utf-8") as handle:
+        json.dump(summary, handle, indent=2)
+    print(json.dumps(summary, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_memory_coupling_audit.py
+++ b/tests/test_memory_coupling_audit.py
@@ -4,6 +4,7 @@ import pytest
 from echofoam_falsifiability.memory_coupling_audit import (
     BRANCHES,
     Parameters,
+    div_psi_grad_tau,
     laplacian,
     radial_metrics,
     run_assay,
@@ -15,6 +16,13 @@ def test_periodic_laplacian_conserves_sum():
     rng = np.random.default_rng(1)
     field = rng.normal(size=(16, 16))
     assert np.sum(laplacian(field, 1.0)) == pytest.approx(0.0, abs=1e-12)
+
+
+def test_periodic_divergence_conserves_sum():
+    rng = np.random.default_rng(2)
+    psi = rng.normal(size=(16, 16))
+    tau = rng.normal(size=(16, 16))
+    assert np.sum(div_psi_grad_tau(psi, tau, 1.0)) == pytest.approx(0.0, abs=1e-12)
 
 
 def test_radial_metrics_identify_lowest_box_mode():
@@ -44,3 +52,52 @@ def test_assay_is_deterministic_and_paired():
     assert summary_a == summary_b
     assert len(rows_a) == 2 * len(BRANCHES)
     assert set(summary_a["paired_comparisons"]) == set(BRANCHES[1:])
+    assert summary_a["assay_manifest"]["seed"] == 7
+
+
+def test_zero_memory_coupling_makes_memory_branches_equivalent():
+    rng = np.random.default_rng(8)
+    params = Parameters(0.2, 0.1, 0.2, 0.0, 20.0, 0.1, 0.5)
+    psi0 = rng.normal(0.0, 0.1, (16, 16))
+    tau0 = rng.normal(0.0, 0.1, (16, 16))
+    results = [
+        simulate(
+            params, branch, psi0, tau0, np.random.default_rng(9),
+            steps=20, dt=0.01, dx=1.0,
+        )
+        for branch in BRANCHES
+    ]
+    for result in results[1:]:
+        assert result["final_variance"] == pytest.approx(results[0]["final_variance"])
+        assert result["psi_tau_corr"] == pytest.approx(results[0]["psi_tau_corr"])
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"runs": 0},
+        {"steps": 0},
+        {"size": 3},
+        {"dt": 0.0},
+        {"dx": 0.0},
+    ],
+)
+def test_assay_rejects_invalid_domain(kwargs):
+    with pytest.raises(ValueError):
+        run_assay(**kwargs)
+
+
+def test_boundedness_guard_detects_unstable_integration():
+    params = Parameters(1.0, 1.0, 1.0, 1.0, 10.0, -100.0, 0.1)
+    psi0 = np.full((8, 8), 100.0)
+    tau0 = np.zeros((8, 8))
+    result = simulate(
+        params, "full_memory", psi0, tau0, np.random.default_rng(10),
+        steps=10, dt=10.0, dx=1.0,
+    )
+    assert not result["bounded"]
+
+
+def test_radial_metrics_reject_non_square_fields():
+    with pytest.raises(ValueError):
+        radial_metrics(np.zeros((8, 4)), 1.0)

--- a/tests/test_memory_coupling_audit.py
+++ b/tests/test_memory_coupling_audit.py
@@ -1,0 +1,46 @@
+import numpy as np
+import pytest
+
+from echofoam_falsifiability.memory_coupling_audit import (
+    BRANCHES,
+    Parameters,
+    laplacian,
+    radial_metrics,
+    run_assay,
+    simulate,
+)
+
+
+def test_periodic_laplacian_conserves_sum():
+    rng = np.random.default_rng(1)
+    field = rng.normal(size=(16, 16))
+    assert np.sum(laplacian(field, 1.0)) == pytest.approx(0.0, abs=1e-12)
+
+
+def test_radial_metrics_identify_lowest_box_mode():
+    n = 32
+    x = np.arange(n)
+    field = np.sin(2 * np.pi * x / n)[None, :] * np.ones((n, 1))
+    metrics = radial_metrics(field, 1.0)
+    assert metrics["k_star"] == pytest.approx(1.0 / n)
+
+
+@pytest.mark.parametrize("branch", BRANCHES)
+def test_every_branch_runs_and_reports_finite_metrics(branch):
+    rng = np.random.default_rng(4)
+    params = Parameters(0.2, 0.1, 0.2, 0.4, 20.0, 0.1, 0.5)
+    psi0 = rng.normal(0.0, 0.1, (16, 16))
+    tau0 = rng.normal(0.0, 0.1, (16, 16))
+    result = simulate(params, branch, psi0, tau0, rng, steps=20, dt=0.01, dx=1.0)
+    assert result["bounded"]
+    assert np.isfinite(result["variance_ratio"])
+    assert np.isfinite(result["prominence"])
+
+
+def test_assay_is_deterministic_and_paired():
+    rows_a, summary_a = run_assay(runs=2, steps=20, size=16, seed=7)
+    rows_b, summary_b = run_assay(runs=2, steps=20, size=16, seed=7)
+    assert rows_a == rows_b
+    assert summary_a == summary_b
+    assert len(rows_a) == 2 * len(BRANCHES)
+    assert set(summary_a["paired_comparisons"]) == set(BRANCHES[1:])

--- a/tests/test_simulations.py
+++ b/tests/test_simulations.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import importlib
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 import unittest
 from matplotlib.figure import Figure
@@ -7,7 +8,7 @@ from matplotlib.animation import FuncAnimation
 
 class TestCreateAnimation(unittest.TestCase):
     def _check_module(self, module_name):
-        mod = __import__(module_name)
+        mod = importlib.import_module(module_name)
         if not hasattr(mod, "create_animation"):
             self.fail(f"{module_name}.create_animation does not exist")
         fig, anim = mod.create_animation()
@@ -24,7 +25,7 @@ class TestCreateAnimation(unittest.TestCase):
         self._check_module("weather_simulation")
 
     def test_laser_filamentation(self):
-        self._check_module("laser_filamentation")
+        self._check_module("echofoam_falsifiability.laser_filamentation")
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Purpose

Reset the repository around auditable, mechanism-first numerical assays while preserving the historical development record.

## Changes

- replaces the README's theory-confirmation framing with an explicit scientific status table
- documents reproduced, falsified, unverified, and open claims
- establishes `src/echofoam_falsifiability/` as the canonical package
- adds a root `pyproject.toml`
- adds the repaired delayed-memory matched-control assay
- compares full memory against no-memory, fixed-spatial-shuffle, and instantaneous controls
- adds invariant, boundedness, deterministic, domain-validation, and paired-design tests
- adds Python 3.10–3.12 CI with independent matrix reporting
- documents legacy duplicates and a non-destructive migration plan
- ignores generated simulation artifacts

## Important finding carried into the repository

The reconstructed legacy memory simulation produces lowest-box-mode behavior across all branches. Delayed memory changes field correlation without an obvious paired separation in the reported pattern metrics. Because the current analysis has no confirmatory uncertainty calculation or preregistered material-effect threshold, the earlier resonance interpretation is not reproduced by this reconstruction and the confirmatory status remains inconclusive.

## Deliberately deferred

This PR does not delete or relocate legacy files. A later PR should inventory them by content hash, import users, and stated claim before moving unique history under `legacy/`.